### PR TITLE
ci - fix release pipeline

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -65,7 +65,7 @@ jobs:
           result=$(make publish || true)
           is_file_name_exists_error=$(echo "$result" | grep "This filename has already been used, use a different version" 2>/dev/null || true)
           if [ -n "$is_file_name_exists_error" ]; then
-            echo "File name already exists, all good!
+            echo "File name already exists, all good!"
           else
             echo "Unhandled exception:"
             echo "$result"

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,75 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+name: Release to PyPi - Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      PACKAGE_VERSION:
+        description: "Package Version"
+        required: true
+        default: "23.23.23rc23"
+
+# TODO: Check why "id-token" doesn't work with PyPi's Truster Publisher
+# https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+permissions:
+  id-token: write
+  contents: write # To create the tag for workflow_dispatch
+
+run-name: Published ${{ inputs.PACKAGE_VERSION }} by @${{ github.actor }}
+
+env:
+  PACKAGE_VERSION: ${{ github.event.inputs.PACKAGE_VERSION }}
+
+jobs:
+  publish:
+    timeout-minutes: 10
+    runs-on: ubuntu-22.04
+    env:
+      RELEASE_REF: ${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: pip
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v4
+      - name: Prepare .VENV directory
+        run: make venv-prepare
+      - name: Install Python dependencies
+        run: make venv-install
+      - name: Set Release Version - GitHub Release
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          export PACKAGE_VERSION=${GITHUB_REF_SLUG}
+          echo -n $PACKAGE_VERSION > ./version
+          echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_ENV
+      - name: Set Release Version - Workflow Dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo -n $PACKAGE_VERSION > ./version
+      - name: Validate Release Version
+        run: make validate-release-version PACKAGE_NAME=${PACKAGE_VERSION}
+      - name: Build Package
+        run: make build
+      - name: Validate Package
+        run: make validate-release-package
+      - name: Publish to PyPi
+        env:
+          TWINE_NON_INTERACTIVE: true
+          TWINE_USERNAME: ${{ secrets.PYPI_USER_NAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: make publish
+      - name: Create tag
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ env.PACKAGE_VERSION }}',
+              sha: context.sha
+            })

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -61,7 +61,15 @@ jobs:
           TWINE_NON_INTERACTIVE: true
           TWINE_USERNAME: ${{ secrets.PYPI_USER_NAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: make publish
+        run: |
+          result=$(make publish || true)
+          is_file_name_exists_error=$(echo "$result" | grep "This filename has already been used, use a different version" 2>/dev/null || true)
+          if [ -n "$is_file_name_exists_error" ]; then
+            echo "File name already exists, all good!
+          else
+            echo "Unhandled exception:"
+            echo "$result"
+          fi
       - name: Create tag
         if: github.event_name == 'workflow_dispatch'
         uses: actions/github-script@v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ env:
 
 jobs:
   tests:
+    name: Tests
     timeout-minutes: 10
     runs-on: windows-2022
     steps:

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ audacity-restart: audacity-kill audacity-start
 ##----
 venv-prepare: ## Create a Python virtual environment with venv
 	python -m venv ${VENV_DIR_PATH} && \
-	python -m pip install -U pip wheel && \
+	python -m pip install -U pip wheel setuptools && \
 	ls ${VENV_DIR_PATH}
 
 venv-install: ## Install Python packages


### PR DESCRIPTION
- Added `release-test.yml` pipeline to test the release pipeline before creating a new release. The pipeline can fail in case of "file exists in PyPi" error.
- Added a `name` to the `tests.yml - tests` job; it's prettier with `Tests` rather than `tests.`
- Re-Added `setuptools` to initial `.venv` preparation.